### PR TITLE
expiration for request persistent cache 

### DIFF
--- a/request/amplify.request.js
+++ b/request/amplify.request.js
@@ -198,10 +198,8 @@ if ( amplify.store ) {
 				return false;
 			}
 			var success = ajaxSettings.success;
-			ajaxSettings.success = function( data ) {
-				var expires = ( 'expires' in resource ) ? resource.expires : undefined;
-			
-				amplify.store[ type]( cacheKey, data , { expires: expires } );
+			ajaxSettings.success = function( data ) {			
+				amplify.store[ type]( cacheKey, data , { expires: resource.expires } );
 				success.apply( this, arguments );
 			};
 		};

--- a/request/amplify.request.js
+++ b/request/amplify.request.js
@@ -198,8 +198,8 @@ if ( amplify.store ) {
 				return false;
 			}
 			var success = ajaxSettings.success;
-			ajaxSettings.success = function( data ) {			
-				amplify.store[ type]( cacheKey, data , { expires: resource.expires } );
+			ajaxSettings.success = function( data ) {	
+				amplify.store[ type]( cacheKey, data , { expires: resource.cache.expires } );
 				success.apply( this, arguments );
 			};
 		};
@@ -210,6 +210,9 @@ if ( amplify.store ) {
 amplify.subscribe( "request.before.ajax", function( resource ) {
 	var cacheType = resource.cache;
 	if ( cacheType ) {
+		if ( typeof cacheType === 'object' ) {
+			cacheType = cacheType.type;
+		}
 		return cache[ cacheType in cache ? cacheType : "_default" ]
 			.apply( this, arguments );
 	}

--- a/request/amplify.request.js
+++ b/request/amplify.request.js
@@ -200,9 +200,7 @@ if ( amplify.store ) {
 			var success = ajaxSettings.success;
 			ajaxSettings.success = function( data ) {
 				var expires = ( 'expires' in resource ) ? resource.expires : undefined;
-				if ( expires ) {
-					delete resource[ 'expires' ];
-				}
+			
 				amplify.store[ type]( cacheKey, data , { expires: expires } );
 				success.apply( this, arguments );
 			};

--- a/request/amplify.request.js
+++ b/request/amplify.request.js
@@ -199,7 +199,11 @@ if ( amplify.store ) {
 			}
 			var success = ajaxSettings.success;
 			ajaxSettings.success = function( data ) {
-				amplify.store[ type]( cacheKey, data );
+				var expires = ( 'expires' in resource ) ? resource.expires : undefined;
+				if ( expires ) {
+					delete resource[ 'expires' ];
+				}
+				amplify.store[ type]( cacheKey, data , { expires: expires } );
 				success.apply( this, arguments );
 			};
 		};

--- a/request/test/unit.js
+++ b/request/test/unit.js
@@ -864,7 +864,7 @@ if ( amplify.store ) {
 		// should execute for first request only
 		subscribe( "request.before.ajax", function( resource ) {
 			equal( resource.resourceId, "persist-cache", "before.ajax message: resource.resourceId" );
-			equal( resource.expires, undefined, "before.ajax message: resource.expires");
+			equal( resource.cache.expires, undefined, "before.ajax message: resource.expires");
 		});
 		// should execute for both requests
 		subscribe( "request.success", function( settings, data ) {
@@ -888,7 +888,7 @@ if ( amplify.store ) {
 		});
 	});
 	
-	asyncTest( "cache: persist - with expires", {
+	asyncTest( "cache: persist - with cache options", {
 		setup: function() {
 			$.each( amplify.store(), function( key ) {
 				if ( /^request/.test( key ) ) {
@@ -909,8 +909,7 @@ if ( amplify.store ) {
 		amplify.request.define( "persist-cache", "ajax", {
 			url: "data/data.json",
 			dataType: "json",
-			cache: "persist",
-			expires: 450
+			cache: { type: 'persist', expires: 450 }
 		});
 		
 		// should execute for both requests
@@ -920,7 +919,7 @@ if ( amplify.store ) {
 		// should execute for first request only
 		subscribe( "request.before.ajax", function( resource ) {
 			equal( resource.resourceId, "persist-cache", "before.ajax message: resource.resourceId" );
-			equal( resource.expires, 450, "before.ajax message: resource.expires");
+			equal( resource.cache.expires, 450, "before.ajax message: resource.expires");
 		});
 		// should execute for both requests
 		subscribe( "request.success", function( settings, data ) {


### PR DESCRIPTION
This adds an expiration option to request definitions so that when a persistent cache is chosen, you can define its expiration.
