### PR TITLE
Request bugs: cache off replaced url

### DIFF
--- a/request/amplify.request.js
+++ b/request/amplify.request.js
@@ -143,8 +143,8 @@ amplify.request.types.ajax = function( defnSettings ) {
 
 
 var cache = amplify.request.cache = {
-	_key: function( resourceId, data ) {
-		var length = data.length,
+	_key: function( resourceId, url ) {
+		var length = url.length,
 			i = 0,
 			checksum = chunk();
 
@@ -153,10 +153,10 @@ var cache = amplify.request.cache = {
 		}
 
 		function chunk() {
-			return data.charCodeAt( i++ ) << 24 |
-				data.charCodeAt( i++ ) << 16 |
-				data.charCodeAt( i++ ) << 8 |
-				data.charCodeAt( i++ ) << 0;
+			return url.charCodeAt( i++ ) << 24 |
+				url.charCodeAt( i++ ) << 16 |
+				url.charCodeAt( i++ ) << 8 |
+				url.charCodeAt( i++ ) << 0;
 		}
 
 		return "request-" + resourceId + "-" + checksum;

--- a/request/amplify.request.js
+++ b/request/amplify.request.js
@@ -190,7 +190,7 @@ var cache = amplify.request.cache = {
 if ( amplify.store ) {
 	$.each( amplify.store.types, function( type ) {
 		cache[ type ] = function( resource, settings, ajaxSettings ) {
-			var cacheKey = cache._key( resource.resourceId, ajaxSettings.data ),
+			var cacheKey = cache._key( resource.resourceId, ajaxSettings.url ),
 				cached = amplify.store[ type ]( cacheKey );
 
 			if ( cached ) {

--- a/request/amplify.request.js
+++ b/request/amplify.request.js
@@ -166,7 +166,7 @@ var cache = amplify.request.cache = {
 		var memoryStore = {};
 		return function( resource, settings, ajaxSettings ) {
 			// data is already converted to a string by the time we get here
-			var cacheKey = cache._key( resource.resourceId, ajaxSettings.data ),
+			var cacheKey = cache._key( resource.resourceId, ajaxSettings.url ),
 				duration = resource.cache;
 
 			if ( cacheKey in memoryStore ) {

--- a/request/test/unit.js
+++ b/request/test/unit.js
@@ -947,6 +947,33 @@ if ( amplify.store ) {
 			}, 500 );
 		});
 	});
+	
+	// see issue: http://groups.google.com/group/amplifyjs/browse_thread/thread/c6d2dc7a7f0a789e
+	asyncTest( "cache: key from ajaxSettings.url", function() {
+		expect( 1 );
+
+		var ajaxCalls = 0;
+
+		amplify.request.define( "url-cache", "ajax", {
+			url: "{url}",
+			dataType: "json",
+			cache: "persist"
+		});
+
+		subscribe( "request.before.ajax", function( resource ) {
+			ajaxCalls++;
+		});
+
+		amplify.request( 'url-cache', { url: "data/data.json" }, function( data ) {
+			amplify.request( 'url-cache', { url: "data/data.json?page=1" }, function( data ) {
+				amplify.request( 'url-cache', { url: "data/data.json?page=2" }, function( data ) {
+					equal( ajaxCalls, 3, "should not cache if url changes" );
+					start();
+				});
+			});
+		});
+
+	});
 
 	test( "cache types", function() {
 		$.each( amplify.store.types, function( type ) {


### PR DESCRIPTION
I know this may be up in the air still, if not, this should work fine... 

While it would ideal for everyone to pass in data to replace url replacements, rather than pass in an entire url as data (which kinda defeats the purpose of amplify.request), I think users may try the ladder anyhow and I guess it needs to be able to handle that?
