### PR TITLE
Small refactor of the URL replacement code

### DIFF
--- a/request/amplify.request.js
+++ b/request/amplify.request.js
@@ -89,7 +89,8 @@ amplify.request.define = function( resourceId, type, settings ) {
 
 (function( amplify, $, undefined ) {
 
-var xhrProps = [ "status", "statusText", "responseText", "responseXML", "readyState" ];
+var xhrProps = [ "status", "statusText", "responseText", "responseXML", "readyState" ],
+    simple_template = /\{([-a-zA-Z0-9_]+)\}/g;
 
 amplify.request.types.ajax = function( defnSettings ) {
 	defnSettings = $.extend({
@@ -102,6 +103,7 @@ amplify.request.types.ajax = function( defnSettings ) {
 			data = settings.data,
 			abort = request.abort,
 			ajaxSettings = {},
+			mapped_keys = [],
 			aborted = false,
 			ampXHR = {
 				readyState: 0,
@@ -135,12 +137,15 @@ amplify.request.types.ajax = function( defnSettings ) {
 
 		if ( typeof data !== "string" ) {
 			data = $.extend( true, {}, defnSettings.data, data );
-			$.each( data, function( key, value ) {
-				regex = new RegExp( "{" + key + "}", "g");
-				if ( regex.test( url ) ) {
-					url = url.replace( regex, value );
-					delete data[ key ];
-				}
+			
+			url = (url || "").replace( simple_template, function ( m, key ) {
+				if ( typeof data[ key ] !== "undefined" ) {
+					return mapped_keys.push( key ) && data[ key ];
+				} 
+			});
+			// We delete the keys later so duplicates are still replaced
+			$.each( mapped_keys, function ( i, key ) {
+				delete data[ key ];
 			});
 		}
 

--- a/request/amplify.request.js
+++ b/request/amplify.request.js
@@ -90,7 +90,7 @@ amplify.request.define = function( resourceId, type, settings ) {
 (function( amplify, $, undefined ) {
 
 var xhrProps = [ "status", "statusText", "responseText", "responseXML", "readyState" ],
-    simple_template = /\{([-a-zA-Z0-9_]+)\}/g;
+    rurlData = /\{([^\}]+)\}/g;
 
 amplify.request.types.ajax = function( defnSettings ) {
 	defnSettings = $.extend({
@@ -98,12 +98,12 @@ amplify.request.types.ajax = function( defnSettings ) {
 	}, defnSettings );
 
 	return function( settings, request ) {
-		var regex, xhr,
+		var xhr,
 			url = defnSettings.url,
 			data = settings.data,
 			abort = request.abort,
 			ajaxSettings = {},
-			mapped_keys = [],
+			mappedKeys = [],
 			aborted = false,
 			ampXHR = {
 				readyState: 0,
@@ -138,13 +138,15 @@ amplify.request.types.ajax = function( defnSettings ) {
 		if ( typeof data !== "string" ) {
 			data = $.extend( true, {}, defnSettings.data, data );
 			
-			url = (url || "").replace( simple_template, function ( m, key ) {
-				if ( typeof data[ key ] !== "undefined" ) {
-					return mapped_keys.push( key ) && data[ key ];
-				} 
+			url = url.replace( rurlData, function ( m, key ) {
+				if ( key in data ) {
+				    mappedKeys.push( key );
+				    return data[ key ];
+				}
 			});
+			
 			// We delete the keys later so duplicates are still replaced
-			$.each( mapped_keys, function ( i, key ) {
+			$.each( mappedKeys, function ( i, key ) {
 				delete data[ key ];
 			});
 		}

--- a/request/test/unit.js
+++ b/request/test/unit.js
@@ -557,6 +557,7 @@ test( "data merging", function() {
 		}, "default data passed through" );
 	};
 	amplify.request.define( "test", "ajax", {
+		url: "",
 		data: {
 			foo: "bar",
 			bar: "baz",
@@ -577,6 +578,7 @@ test( "data merging", function() {
 		}, "data merged" );
 	};
 	amplify.request.define( "test", "ajax", {
+		url: "",
 		data: {
 			foo: "bar",
 			bar: "baz",


### PR DESCRIPTION
I ran some speed tests on the method currently used by Amplify to replace URL parameters with passed in data. I found using a regular expression replace with a callback was faster than redefining RegExp's for each item in a data structure.

You can see my perf tests here: http://jsperf.com/quick-templates-compared/2

These two commits handle the change to the faster method.
