### PR TITLE
Added ability to override a cache (for amplify.store cache types)

### DIFF
--- a/request/amplify.request.js
+++ b/request/amplify.request.js
@@ -263,7 +263,8 @@ if ( amplify.store ) {
 		cache[ type ] = function( resource, settings, ajaxSettings, ampXHR ) {
 			var cacheKey = cache._key( settings.resourceId,
 					ajaxSettings.url, ajaxSettings.data ),
-				cached = amplify.store[ type ]( cacheKey );
+				cached = amplify.store[ type ]( cacheKey,
+					resource.cache.override ? null : undefined );
 
 			if ( cached ) {
 				ajaxSettings.success( cached );


### PR DESCRIPTION
Pass an `override: true` property in the `cache` setting, and it will perform the ajax request and replace an existing cache.

Example:

```
amplify.request( "persist-cache", { cache: { type: "persist", override: true } }, ...
```

Useful when you perform an action that you know modifies the result of a previously-cached request.

Use case 1: I'm listing a node in a tree. I request the content of the current node, caching the result for 5 minutes. I have a "create node" button that will create a new node inside the current node. Any request for the current node won't show the newly created node until the end of the 5 minutes caching period.

Use case 2: refresh button.
