### PR TITLE
amplify.request contained a semi-colon instead of a comma, creating several global variables.

### DIFF
--- a/request/amplify.request.js
+++ b/request/amplify.request.js
@@ -119,7 +119,7 @@ amplify.request.types.ajax = function( defnSettings ) {
 		var xhr,
 			url = defnSettings.url,
 			abort = request.abort,
-			ajaxSettings = $.extend( true, {}, defnSettings, { data: settings.data } );
+			ajaxSettings = $.extend( true, {}, defnSettings, { data: settings.data } ),
 			aborted = false,
 			ampXHR = {
 				readyState: 0,


### PR DESCRIPTION
Variable declarations were terminated with a semi-colon and not with a
comma, making all subsequent variables global.
