### PR TITLE
Accessing window.globalStorage throws a warning in Firefox 9

### DIFF
--- a/store/amplify.store.js
+++ b/store/amplify.store.js
@@ -123,7 +123,7 @@ for ( var webStorageType in { localStorage: 1, sessionStorage: 1 } ) {
 // globalStorage
 // non-standard: Firefox 2+
 // https://developer.mozilla.org/en/dom/storage#globalStorage
-if ( window.globalStorage ) {
+if ( !store.types.localStorage && window.globalStorage ) {
 	// try/catch for file protocol in Firefox
 	try {
 		createFromStorageInterface( "globalStorage",


### PR DESCRIPTION
This checks if localStorage is available before attempting to use globalStorage.
