### PR TITLE
Issue #46 - Multiple topics documentation and 'topic' callback argument added

### DIFF
--- a/core/amplify.core.js
+++ b/core/amplify.core.js
@@ -25,6 +25,8 @@ var amplify = global.amplify = {
 			return true;
 		}
 
+		args.push( topic );
+
 		topicSubscriptions = subscriptions[ topic ].slice();
 		for ( length = topicSubscriptions.length; i < length; i++ ) {
 			subscription = topicSubscriptions[ i ];

--- a/core/readme.md
+++ b/core/readme.md
@@ -115,3 +115,25 @@ proceeding.
 	
 	amplify.publish( "priorityexample", { foo: "bar" } );
 	amplify.publish( "priorityexample", { foo: "oops" } );
+
+### Subscribing to multiple topics
+
+Subscribe to "foo", "bar" and "baz", using the same callback.
+
+    amplify.subscribe( "foo bar baz", function( data ) {
+        console.log( "data: " + data );
+    } );
+
+### Subscribing to multiple topics and identifying the topic published
+
+When subscribing to multiple topics you can pass the option `topic` parameter 
+at the end of the callback function. This will give you access to the topic that 
+is being published. 
+
+	amplify.subscribe( "lion kitty dog", function( data, topic ) {
+		console.log( "The " + topic + " says '" + data.bar + "'." );
+	});
+
+	amplify.publish( "lion", { bar: "RAWR!" } );         // The lion says 'RAWR!'.
+	amplify.publish( "kitty", { bar: "meow" } );         // The kitty says 'meow'.
+	amplify.publish( "dog", { bar: "Woof!" } );          // The dog says 'Woof!'.

--- a/core/test/unit.js
+++ b/core/test/unit.js
@@ -155,7 +155,7 @@ test( "unsubscribe during publish", function() {
 });
 
 test( "multiple subscriptions", function() {
-	expect( 4 );
+	expect( 6 );
 
 	amplify.subscribe( "sub-a-1 sub-a-2 sub-a-3", function() {
 		ok( true );
@@ -174,4 +174,18 @@ test( "multiple subscriptions", function() {
 	amplify.publish( "sub-b-2" );
 	amplify.publish( "sub-b-2" );
 	amplify.publish( "sub-b-3" );
+
+	// Test for Ticket #46
+	amplify.subscribe( "sub-c-1 sub-c-2", function( foo, topic ) {
+		if ( topic === "sub-c-1" ) {
+			ok( true );
+		} else if (topic === "sub-c-2") {
+			ok( true );
+		} else {
+			ok( false );
+		}
+	});
+
+	amplify.publish( "sub-c-2", "hello, world!" );
+	amplify.publish( "sub-c-1", "hello, world!" );
 });


### PR DESCRIPTION
Reading through @ifandelse's pull request (https://github.com/appendto/amplify/pull/47) I felt like we could solve the identifying the topic pretty easily and explored that approach in this pull request. 

I've included the multiple topic documentation that @ifandelse started then extended amplify to include the passing of 'topic' as the last argument to the callback function, optional of course. here's the examples of how this would work: 

```
amplify.subscribe( "lion kitty dog", function( data, topic ) {
    console.log( "The " + topic + " says '" + data.bar + "'." );
});

amplify.publish( "lion", { bar: "RAWR!" } );         // The lion says 'RAWR!'.
amplify.publish( "kitty", { bar: "meow" } );         // The kitty says 'meow'.
amplify.publish( "dog", { bar: "Woof!" } );          // The dog says 'Woof!'.
```

I've included tests and documentation for subscribing multiple topics and identifying the topic published. 
