### PR TITLE
Add the topic to the callback method before executing the callback

### DIFF
--- a/core/amplify.core.js
+++ b/core/amplify.core.js
@@ -28,6 +28,7 @@ var amplify = global.amplify = {
 		topicSubscriptions = subscriptions[ topic ].slice();
 		for ( length = topicSubscriptions.length; i < length; i++ ) {
 			subscription = topicSubscriptions[ i ];
+			subscription.callback.topic = topic;
 			ret = subscription.callback.apply( subscription.context, args );
 			if ( ret === false ) {
 				break;

--- a/core/readme.md
+++ b/core/readme.md
@@ -14,12 +14,14 @@ It is possible to implement the publish and subscribe model by using jQuery cust
 
 Subscribe to a message.
 
-* `topic`: Name of the message to subscribe to.
+* `topic`: Name of the message to subscribe to. Multiple topics can be provided, separated by a space.
 * [`context`]: What `this` will be when the callback is invoked.
 * `callback`: Function to invoke when the message is published.
 * [`priority`]: Priority relative to other subscriptions for the same message. Lower values have higher priority. Default is 10.
 
 > Returning `false` from a subscription will prevent any additional subscriptions from being invoked and will cause `amplify.publish` to return `false`.
+
+You can find out which topic is currently being processed by accessing the `topic` property on your callback method. This is especially helpful when dealing with multiple topics in a single subscription. *Important: `topic` is only available for the duration of the callback function&rsquo;s execution. If you defer/throttle or otherwise delay accessing the topic, it may no longer be the correct topic.* The easiest way to access this property is to use a named callback method.
 
 <pre><code>amplify.unsubscribe( string topic, function callback )</code></pre>
 
@@ -115,3 +117,22 @@ proceeding.
 	
 	amplify.publish( "priorityexample", { foo: "bar" } );
 	amplify.publish( "priorityexample", { foo: "oops" } );
+
+### Subscribe to multiple topics in a single callback
+
+You can subscribe to multiple topics by separating them by spaces. If you name your callback function, you can access the topic currently being handled through the `topic` property.
+
+	amplify.subscribe( "topic1 topic2 topic3", function topicCallback( data ) {
+		if ( topicCallback.topic === "topic1" ) {
+			// Do something for topic1
+		} else {
+			// Do something different for topic2 and topic 3
+		}
+
+		// More code that runs for any of the three topics
+	});
+
+	//...
+
+	amplify.publish( "topic1", { foo: "bar" } );
+	amplify.publish( "topic2", { foo: "baz" } );

--- a/core/readme.md
+++ b/core/readme.md
@@ -21,7 +21,7 @@ Subscribe to a message.
 
 > Returning `false` from a subscription will prevent any additional subscriptions from being invoked and will cause `amplify.publish` to return `false`.
 
-You can find out which topic is currently being processed by accessing the `topic` property on your callback method. This is especially helpful when dealing with multiple topics in a single subscription. *Important: `topic` is only available for the duration of the callback function&rsquo;s execution. If you defer/throttle or otherwise delay accessing the topic, it may no longer be the correct topic.* The easiest way to access this property is to use a named callback method.
+You can find out which topic is currently being published by accessing the `topic` property on your callback method. This is especially helpful when dealing with multiple topics in a single subscription. *Important: `topic` is only available for the duration of the callback function's execution. If you defer/throttle or otherwise delay accessing the topic, it may no longer be the correct topic.* The easiest way to access this property is to use a named callback method.
 
 <pre><code>amplify.unsubscribe( string topic, function callback )</code></pre>
 

--- a/core/test/unit.js
+++ b/core/test/unit.js
@@ -175,3 +175,21 @@ test( "multiple subscriptions", function() {
 	amplify.publish( "sub-b-2" );
 	amplify.publish( "sub-b-3" );
 });
+
+test( "topic on callback", function () {
+	expect( 2 );
+
+	var firstTime = true;
+
+	amplify.subscribe( "topic-a-1 topic-a-2 topic-a-3", function namedCallback() {
+		if ( firstTime ) {
+			strictEqual( namedCallback.topic, "topic-a-2", "topic provided" );
+			firstTime = false;
+		} else {
+			strictEqual( namedCallback.topic, "topic-a-1", "topic provided" );
+		}
+	});
+
+	amplify.publish( "topic-a-2" );
+	amplify.publish( "topic-a-1" );
+});


### PR DESCRIPTION
This allows the developer to access the current topic being handled by the callback without breaking existing implementations of amplify pub/sub. The example in the readme shows how to access this new property.

Also update the readme to clarify that multiple topics can be subscribed in a single subscribe call.
