### PR TITLE
Passing an undefined topic to the pub/sub methods should cause an Error

### DIFF
--- a/core/amplify.core.js
+++ b/core/amplify.core.js
@@ -14,6 +14,10 @@ var slice = [].slice,
 
 var amplify = global.amplify = {
 	publish: function( topic ) {
+	    if((topic === undefined) || (topic === null)) {
+	        throw new Error("You must provide a valid topic to publish to subscriptions.");
+		}
+			
 		var args = slice.call( arguments, 1 ),
 			topicSubscriptions,
 			subscription,
@@ -37,6 +41,10 @@ var amplify = global.amplify = {
 	},
 
 	subscribe: function( topic, context, callback, priority ) {
+	    if((topic === undefined) || (topic === null)) {
+	        throw new Error("You must provide a valid topic to create a subscription.");
+		}
+		
 		if ( arguments.length === 3 && typeof callback === "number" ) {
 			priority = callback;
 			callback = context;
@@ -83,6 +91,10 @@ var amplify = global.amplify = {
 	},
 
 	unsubscribe: function( topic, callback ) {
+	    if((topic === undefined) || (topic === null)) {
+	        throw new Error("You must provide a valid topic to remove a subscription.");
+		}
+		
 		if ( !subscriptions[ topic ] ) {
 			return;
 		}

--- a/core/amplify.core.js
+++ b/core/amplify.core.js
@@ -15,7 +15,7 @@ var slice = [].slice,
 var amplify = global.amplify = {
 	publish: function( topic ) {
 		if ( typeof topic !== "string" ) {
-	        throw new Error("You must provide a valid topic to publish to subscriptions.");
+			throw new Error("You must provide a valid topic to publish to subscriptions.");
 		}
 
 		var args = slice.call( arguments, 1 ),
@@ -42,7 +42,7 @@ var amplify = global.amplify = {
 
 	subscribe: function( topic, context, callback, priority ) {
 		if ( typeof topic !== "string" ) {
-	        throw new Error("You must provide a valid topic to create a subscription.");
+			throw new Error("You must provide a valid topic to create a subscription.");
 		}
 
 		if ( arguments.length === 3 && typeof callback === "number" ) {

--- a/core/amplify.core.js
+++ b/core/amplify.core.js
@@ -14,7 +14,7 @@ var slice = [].slice,
 
 var amplify = global.amplify = {
 	publish: function( topic ) {
-	    if((topic === undefined) || (topic === null)) {
+	    if( typeof topic !== "string") {
 	        throw new Error("You must provide a valid topic to publish to subscriptions.");
 		}
 			
@@ -41,7 +41,7 @@ var amplify = global.amplify = {
 	},
 
 	subscribe: function( topic, context, callback, priority ) {
-	    if((topic === undefined) || (topic === null)) {
+	    if( typeof topic !== "string") {
 	        throw new Error("You must provide a valid topic to create a subscription.");
 		}
 		
@@ -91,7 +91,7 @@ var amplify = global.amplify = {
 	},
 
 	unsubscribe: function( topic, callback ) {
-	    if((topic === undefined) || (topic === null)) {
+	    if( typeof topic !== "string") {
 	        throw new Error("You must provide a valid topic to remove a subscription.");
 		}
 		

--- a/core/amplify.core.js
+++ b/core/amplify.core.js
@@ -14,10 +14,10 @@ var slice = [].slice,
 
 var amplify = global.amplify = {
 	publish: function( topic ) {
-	    if( typeof topic !== "string") {
+		if ( typeof topic !== "string" ) {
 	        throw new Error("You must provide a valid topic to publish to subscriptions.");
 		}
-			
+
 		var args = slice.call( arguments, 1 ),
 			topicSubscriptions,
 			subscription,
@@ -41,10 +41,10 @@ var amplify = global.amplify = {
 	},
 
 	subscribe: function( topic, context, callback, priority ) {
-	    if( typeof topic !== "string") {
+		if ( typeof topic !== "string" ) {
 	        throw new Error("You must provide a valid topic to create a subscription.");
 		}
-		
+
 		if ( arguments.length === 3 && typeof callback === "number" ) {
 			priority = callback;
 			callback = context;
@@ -91,10 +91,10 @@ var amplify = global.amplify = {
 	},
 
 	unsubscribe: function( topic, callback ) {
-	    if( typeof topic !== "string") {
-	        throw new Error("You must provide a valid topic to remove a subscription.");
+		if ( typeof topic !== "string" ) {
+			throw new Error("You must provide a valid topic to remove a subscription.");
 		}
-		
+
 		if ( !subscriptions[ topic ] ) {
 			return;
 		}

--- a/core/amplify.core.js
+++ b/core/amplify.core.js
@@ -15,7 +15,7 @@ var slice = [].slice,
 var amplify = global.amplify = {
 	publish: function( topic ) {
 		if ( typeof topic !== "string" ) {
-			throw new Error("You must provide a valid topic to publish to subscriptions.");
+			throw new Error( "You must provide a valid topic to publish to subscriptions." );
 		}
 
 		var args = slice.call( arguments, 1 ),
@@ -42,7 +42,7 @@ var amplify = global.amplify = {
 
 	subscribe: function( topic, context, callback, priority ) {
 		if ( typeof topic !== "string" ) {
-			throw new Error("You must provide a valid topic to create a subscription.");
+			throw new Error( "You must provide a valid topic to create a subscription." );
 		}
 
 		if ( arguments.length === 3 && typeof callback === "number" ) {
@@ -92,7 +92,7 @@ var amplify = global.amplify = {
 
 	unsubscribe: function( topic, callback ) {
 		if ( typeof topic !== "string" ) {
-			throw new Error("You must provide a valid topic to remove a subscription.");
+			throw new Error( "You must provide a valid topic to remove a subscription." );
 		}
 
 		if ( !subscriptions[ topic ] ) {

--- a/core/readme.md
+++ b/core/readme.md
@@ -1,6 +1,6 @@
 # amplify core
 
-The AmplifyJS core library provides two methods (`amplify.publish` and `amplify.subscribe`). AmplifyJS provides methods to facilitate the Publish and Subscribe messaging pattern in your front-end application. The idea is that someone is broadcasting one or more messages (publishing) and someone else is listening to one or more messages (subscribing). By separating your logic out like this it allows for loose coupling of your components, which results in less brittle and more reusable code.
+The AmplifyJS core library provides three methods (`amplify.publish`, `amplify.subscribe`, and `amplify.unsubscribe`). AmplifyJS provides methods to facilitate the Publish and Subscribe messaging pattern in your front-end application. The idea is that someone is broadcasting one or more messages (publishing) and someone else is listening to one or more messages (subscribing). By separating your logic out like this it allows for loose coupling of your components, which results in less brittle and more reusable code.
 
 It is possible to implement the publish and subscribe model by using jQuery custom events, however, the AmplifyJS pub/sub component provides a slightly cleaner interface, prevents collisions between custom events and method names, and allows a priority to your messages.
 

--- a/core/test/unit.js
+++ b/core/test/unit.js
@@ -1,28 +1,28 @@
 module( "amplify.core pubsub" );
 
 test( "topic", function() {
-	expect(3);
-	
+	expect( 3 );
+
 	try {
-		amplify.publish(undefined, function() {} );
+		amplify.publish( undefined, function() {} );
 	}
-	catch (err) {
-		ok(true, err);
+	catch( err ) {
+		strictEqual( err.message, "You must provide a valid topic to publish to subscriptions.", err );
 	}
-	
+
 	try {
-		amplify.subscribe(undefined, function() {} );
+		amplify.subscribe( undefined, function() {} );
 	}
-	catch (err) {
-		ok(true, err);
+	catch( err ) {
+		strictEqual( err.message, "You must provide a valid topic to create a subscription.", err );
 	}
-	
+
 	try {
-		amplify.unsubscribe(undefined, function() {} );
+		amplify.unsubscribe( undefined, function() {} );
 	}
-	catch (err) {
-		ok(true, err);
-	} 
+	catch( err ) {
+		strictEqual( err.message, "You must provide a valid topic to remove a subscription.", err );
+	}
 });
 
 test( "continuation", function() {

--- a/core/test/unit.js
+++ b/core/test/unit.js
@@ -1,5 +1,30 @@
 module( "amplify.core pubsub" );
 
+test( "topic", function() {
+	expect(3);
+	
+	try {
+		amplify.publish(undefined, function() {} );
+	}
+	catch (err) {
+		ok(true, err);
+	}
+	
+	try {
+		amplify.subscribe(undefined, function() {} );
+	}
+	catch (err) {
+		ok(true, err);
+	}
+	
+	try {
+		amplify.unsubscribe(undefined, function() {} );
+	}
+	catch (err) {
+		ok(true, err);
+	} 
+});
+
 test( "continuation", function() {
 	expect( 7 );
 	amplify.subscribe( "continuation", function() {

--- a/vsdoc/amplify-vsdoc.js
+++ b/vsdoc/amplify-vsdoc.js
@@ -88,7 +88,7 @@ amplify.subscribe = function( topic, callback ) {
 	/// 	&#10;&#09;3. amplify.subscribe( topic, context, callback, priority )
 	/// 	&#10;&#10;API Reference: http://amplifyjs.com/api/pubsub
 	/// </summary>
-	/// <param name="topic" type="String">Name of the message to subscribe to. An error is thrown if topic is null or undefined.</param>
+	/// <param name="topic" type="String">Name of the message to subscribe to.</param>
 	/// <param name="context" type="Object" optional="true">What this will be when the callback is invoked.</param>
 	/// <param name="callback" type="Function">Function to invoke when the message is published.</param>
 	/// <param name="priority" type="Number" optional="true">Priority relative to other subscriptions for the same message. Lower values have higher priority. Default is 10.</param>
@@ -96,7 +96,7 @@ amplify.subscribe = function( topic, callback ) {
  
 amplify.unsubscribe = function( topic, callback ) {
 	/// <summary>Remove a subscription.</summary>
-	/// <param name="topic" type="String">The topic being unsubscribed from. An error is thrown if topic is null or undefined.</param>
+	/// <param name="topic" type="String">The topic being unsubscribed from.</param>
 	/// <param name="callback" type="Function">The callback that was originally subscribed.</param>
 };
 
@@ -106,6 +106,6 @@ amplify.publish = function( topic ) {
 	/// &#10;Any number of additional parameters can be passed to the subscriptions
 	/// &#10;&#10;API Reference: http://amplifyjs.com/api/pubsub
 	/// </summary>
-	/// <param name="topic" type="String">The name of the message to publish. An error is thrown if topic is null or undefined.</param>
+	/// <param name="topic" type="String">The name of the message to publish.</param>
 	/// <returns type="Boolean">amplify.publish returns a boolean indicating whether any subscriptions returned false. The return value is true if none of the subscriptions returned false, and false otherwise. Note that only one subscription can return false because doing so will prevent additional subscriptions from being invoked.</returns>
 };

--- a/vsdoc/amplify-vsdoc.js
+++ b/vsdoc/amplify-vsdoc.js
@@ -88,7 +88,7 @@ amplify.subscribe = function( topic, callback ) {
 	/// 	&#10;&#09;3. amplify.subscribe( topic, context, callback, priority )
 	/// 	&#10;&#10;API Reference: http://amplifyjs.com/api/pubsub
 	/// </summary>
-	/// <param name="topic" type="String">Name of the message to subscribe to.</param>
+	/// <param name="topic" type="String">Name of the message to subscribe to. An error is thrown if topic is null or undefined.</param>
 	/// <param name="context" type="Object" optional="true">What this will be when the callback is invoked.</param>
 	/// <param name="callback" type="Function">Function to invoke when the message is published.</param>
 	/// <param name="priority" type="Number" optional="true">Priority relative to other subscriptions for the same message. Lower values have higher priority. Default is 10.</param>
@@ -96,7 +96,7 @@ amplify.subscribe = function( topic, callback ) {
  
 amplify.unsubscribe = function( topic, callback ) {
 	/// <summary>Remove a subscription.</summary>
-	/// <param name="topic" type="String">The topic being unsubscribed from.</param>
+	/// <param name="topic" type="String">The topic being unsubscribed from. An error is thrown if topic is null or undefined.</param>
 	/// <param name="callback" type="Function">The callback that was originally subscribed.</param>
 };
 
@@ -106,6 +106,6 @@ amplify.publish = function( topic ) {
 	/// &#10;Any number of additional parameters can be passed to the subscriptions
 	/// &#10;&#10;API Reference: http://amplifyjs.com/api/pubsub
 	/// </summary>
-	/// <param name="topic" type="String">The name of the message to publish.</param>
+	/// <param name="topic" type="String">The name of the message to publish. An error is thrown if topic is null or undefined.</param>
 	/// <returns type="Boolean">amplify.publish returns a boolean indicating whether any subscriptions returned false. The return value is true if none of the subscriptions returned false, and false otherwise. Note that only one subscription can return false because doing so will prevent additional subscriptions from being invoked.</returns>
 };


### PR DESCRIPTION
## Current Behavior
- publish: _No Error_
- subscribe: **Error** _Cannot call method 'split' of undefined_
- unsubscribe: _No Error_
## Proposed Behavior

I am proposing all three methods throw an appropriate error when passed either null or undefined
- publish: **Error** _You must provide a valid topic to publish to subscriptions._
- subscribe: **Error** _You must provide a valid topic to create a subscription._
- unsubscribe: **Error** _You must provide a valid topic to remove a subscription._
