### PR TITLE
Request: Early flush cache

### DIFF
--- a/request/amplify.request.js
+++ b/request/amplify.request.js
@@ -289,7 +289,7 @@ var cache = amplify.request.cache = {
 					ajaxSettings.url, ajaxSettings.data ),
 				duration = resource.cache;
 
-			if ( cacheKey in memoryStore ) {
+			if ( cacheKey in memoryStore && !settings.flushCache ) {
 				ampXHR.success( memoryStore[ cacheKey ] );
 				return false;
 			}
@@ -314,7 +314,7 @@ if ( amplify.store ) {
 					ajaxSettings.url, ajaxSettings.data ),
 				cached = amplify.store[ type ]( cacheKey );
 
-			if ( cached ) {
+			if ( cached && !settings.flushCache ) {
 				ajaxSettings.success( cached );
 				return false;
 			}


### PR DESCRIPTION
Added param for reset request-cache.
Example:
amplify.request({
resourceId: 'foo',
flushCache: true
})
