### PR TITLE
Add support for getting the fully formatted url using amplify.format

### DIFF
--- a/src/request.js
+++ b/src/request.js
@@ -79,7 +79,6 @@ amplify.format = function ( resourceId, data ) {
 
 	if ( typeof settings === "string" ) {
 		if ( isFunction( data ) ) {
-			callback = data;
 			data = {};
 		}
 		settings = {

--- a/src/request.js
+++ b/src/request.js
@@ -73,8 +73,27 @@ amplify.request = function( resourceId, data, callback ) {
 	return request;
 };
 
+amplify.format = function ( resourceId, data ) {
+	
+	var settings = resourceId || {};
+
+	if ( typeof settings === "string" ) {
+		if ( isFunction( data ) ) {
+			callback = data;
+			data = {};
+		}
+		settings = {
+			resourceId: resourceId,
+			data: data || {}
+		};
+	}
+	
+	return amplify.request.urls[ settings.resourceId ]( settings );
+};
+
 amplify.request.types = {};
 amplify.request.resources = {};
+amplify.request.urls = {};
 amplify.request.define = function( resourceId, type, settings ) {
 	if ( typeof type === "string" ) {
 		if ( !( type in amplify.request.types ) ) {
@@ -84,6 +103,8 @@ amplify.request.define = function( resourceId, type, settings ) {
 		settings.resourceId = resourceId;
 		amplify.request.resources[ resourceId ] =
 			amplify.request.types[ type ]( settings );
+		amplify.request.urls[ resourceId ] = 
+			amplify.request.types["define"]( settings );
 	} else {
 		// no pre-processor or settings for one-off types (don't invoke)
 		amplify.request.resources[ resourceId ] = type;
@@ -100,6 +121,28 @@ amplify.request.define = function( resourceId, type, settings ) {
 
 var xhrProps = [ "status", "statusText", "responseText", "responseXML", "readyState" ],
     rurlData = /\{([^\}]+)\}/g;
+    
+amplify.request.types.define = function ( defnSettings ) {
+	return function( settings ) {
+		var url = defnSettings.url;
+		var data = settings.data;
+		var mappedKeys = [];
+		if ( typeof data !== "string" ) {
+			data = $.extend( true, {}, defnSettings.data, data );
+			
+			url = url.replace( rurlData, function ( m, key ) {
+				if ( key in data ) {
+				    mappedKeys.push( key );
+				    return data[ key ];
+				}
+			});
+			
+			return url;
+		}
+		
+		return "";
+	};
+};
 
 amplify.request.types.ajax = function( defnSettings ) {
 	defnSettings = $.extend({


### PR DESCRIPTION
When you call amplify.request.define, this will ensure that 
amplify.request.urls is also set. This allows you to call 
amplify.format to get the formatted url based on the endpoint and 
data you pass to the callback.
