### PR TITLE
Added updated Nuget package spec and Nuget readme file

### DIFF
--- a/AmplifyJS.nuspec
+++ b/AmplifyJS.nuspec
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+        <id>AmplifyJS</id>
+        <version>1.1.2</version>
+        <title>AmplifyJS</title>
+        <authors>http://appendto.com</authors>
+        <licenseUrl>http://amplifyjs.com/#licenses</licenseUrl>
+        <projectUrl>http://amplifyjs.com</projectUrl>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>AmplifyJS solves the following problems: 1. Ajax Request Management - amplify.request provides a clean and elegant request abstraction for all types of data, even allowing for transformation prior to consumption. 2. Client Side Component Communication - amplify.publish/subscribe provides a clean, performant API for component to component communication. 3. Client Side Browser &amp; Mobile Device Storage - amplify.store takes the confusion out of HTML5 localStorage. It doesn't get simpler than using amplify.store(key, data)! It even works flawlessly on mobile devices.</description>
+        <summary>AmplifyJS is a set of components designed to solve common web application problems with a simplistic API.</summary>
+        <language>es-US</language>
+        <tags>javascript jquery html5</tags>
+        <dependencies>
+            <dependency id="jQuery" version="1.4" />
+        </dependencies>
+    </metadata>
+    <files>
+        <file src="lib\amplify-vsdoc.js" target="content\Scripts\amplify-vsdoc.js" />
+        <file src="lib\amplify.js" target="content\Scripts\amplify.js" />
+        <file src="lib\amplify.min.js" target="content\Scripts\amplify.min.js" />
+        <file src="lib\amplify.core.js" target="content\Scripts\amplify\amplify.core.js" />
+        <file src="lib\amplify.core.min.js" target="content\Scripts\amplify\amplify.core.min.js" />
+        <file src="lib\amplify.request.js" target="content\Scripts\amplify\amplify.request.js" />
+        <file src="lib\amplify.request.min.js" target="content\Scripts\amplify\amplify.request.min.js" />
+        <file src="lib\amplify.store.js" target="content\Scripts\amplify\amplify.store.js" />
+        <file src="lib\amplify.store.min.js" target="content\Scripts\amplify\amplify.store.min.js" />
+        <file src="GPL-LICENSE.txt" target="content\Scripts\GPL-LICENSE.txt" />
+        <file src="MIT-LICENSE.txt" target="content\Scripts\MIT-LICENSE.txt" />
+        <file src="nuget-readme.txt" target="content\Scripts\README.txt" />
+    </files>
+</package>

--- a/nuget-readme.txt
+++ b/nuget-readme.txt
@@ -2,22 +2,14 @@ AmplifyJS 1.1.2
 http://amplifyjs.com
 Developed & Maintained by http://appendto.com
 
-Thank you for downloading AmplifyJS 1.1.0! This folder contains the full distribution of 
-the AmplifyJS library including source and minified versions.
+Thank you for downloading AmplifyJS 1.1.2! This download contains the source and minified versions of 
+the complete AmplifyJS library as well as individual components.
 
 [Licensing]
 AmplifyJS is dual licensed under either the MIT or GPL licenses. Both licenses have been included
 in the AmplifyJS download (and should be in the same folder as this file). View MIT-LICENSE.txt or 
 GPL-LICENSE.txt for further details. Additional licensing questions may be directed to
 http://appendto.com or contact@appendto.com.
-
-[Including AmplifyJS In Your Project]
-- To include all AmplifyJS components : Copy amplify.min.js into the appropriate location such as 
-  /js/ and reference it via a <script> tag. This file includes all of the latest versions of the 
-  AmplifyJS components. (http://amplifyjs.com/api/). For help in debugging or to use your own 
-  compression utility, amplify.js is also provided.
-
-- To include individual AmplifyJS components : Copy the appropriate amplify/amplify.<component>.js or amplify/amplify.<component>.min.js into your project and include it with a <script> tag.
 
 For more information about AmplifyJS and the open source community surrounding it, please 
 visit http://amplifyjs.com.

--- a/nuget-readme.txt
+++ b/nuget-readme.txt
@@ -1,0 +1,24 @@
+AmplifyJS 1.1.2
+http://amplifyjs.com
+Developed & Maintained by http://appendto.com
+
+Thank you for downloading AmplifyJS 1.1.0! This folder contains the full distribution of 
+the AmplifyJS library including source and minified versions.
+
+[Licensing]
+AmplifyJS is dual licensed under either the MIT or GPL licenses. Both licenses have been included
+in the AmplifyJS download (and should be in the same folder as this file). View MIT-LICENSE.txt or 
+GPL-LICENSE.txt for further details. Additional licensing questions may be directed to
+http://appendto.com or contact@appendto.com.
+
+[Including AmplifyJS In Your Project]
+- To include all AmplifyJS components : Copy amplify.min.js into the appropriate location such as 
+  /js/ and reference it via a <script> tag. This file includes all of the latest versions of the 
+  AmplifyJS components. (http://amplifyjs.com/api/). For help in debugging or to use your own 
+  compression utility, amplify.js is also provided.
+
+- To include individual AmplifyJS components : Copy the appropriate amplify/amplify.<component>.js or amplify/amplify.<component>.min.js into your project and include it with a <script> tag.
+
+For more information about AmplifyJS and the open source community surrounding it, please 
+visit http://amplifyjs.com.
+

--- a/nuget-readme.txt
+++ b/nuget-readme.txt
@@ -5,6 +5,14 @@ Developed & Maintained by http://appendto.com
 Thank you for downloading AmplifyJS 1.1.2! This download contains the source and minified versions of 
 the complete AmplifyJS library as well as individual components.
 
+[Usage]
+To include the full Amplify JS library (Core, Request and Store) use the `amplify.js` or `amplify.min.js` files.
+
+To use just the components you want, reference the individual `amplify/amplify.<component>.js` or `amplify/amplify.<component>.min.js` files.
+
+* `amplify.store.js` and `amplify.core.js` are completely stand alone.
+* `amplify.request.js` depends on `amplify.core.js`
+
 [Licensing]
 AmplifyJS is dual licensed under either the MIT or GPL licenses. Both licenses have been included
 in the AmplifyJS download (and should be in the same folder as this file). View MIT-LICENSE.txt or 


### PR DESCRIPTION
The AmplifyJS NuGet package has been needing to be updated with the latest code for a while. This request adds the `nuspec` file into Source control (as well as the associated readme) and maps the built output of Amplify to match the existing NuGet structure. The only new addition is the `amplify` folder with individual components inside. The finished package files look like this:

```
/content
  /Scripts
    /amplify
       amplify.core.js
       amplify.core.min.js
       amplify.request.js
       amplify.request.min.js
       amplify.store.js
       amplify.store.min.js
    amplify-vsdoc.js
    amplify.js
    amplify.min.js
    GPL-LICENSE.txt
    MIT-LICENSE.txt
    README.txt
```

After discussing with @elijahmanor I opted to not put the `amplify.js` and `amplify.min.js` files in the `/amplify` directory so those upgrading from an older version of the package wouldn't have trouble with the files moving.

If @jcreamer898 or anyone else with more experience in .NET and NuGet could chime in on this commit, it would be appreciated!
