### PR TITLE
Added null return if there are no subscriptions.

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -22,7 +22,6 @@ var amplify = global.amplify = {
 		}
 
 		topicSubscriptions = subscriptions[ topic ].slice();
-		
 		for ( length = topicSubscriptions.length; i < length; i++ ) {
 			subscription = topicSubscriptions[ i ];
 			ret = subscription.callback.apply( subscription.context, args );

--- a/src/core.js
+++ b/src/core.js
@@ -16,11 +16,13 @@ var amplify = global.amplify = {
 			i = 0,
 			ret;
 
+		//If there not subscriptions please return null to clarify things.
 		if ( !subscriptions[ topic ] ) {
-			return true;
+			return null;
 		}
 
 		topicSubscriptions = subscriptions[ topic ].slice();
+		
 		for ( length = topicSubscriptions.length; i < length; i++ ) {
 			subscription = topicSubscriptions[ i ];
 			ret = subscription.callback.apply( subscription.context, args );


### PR DESCRIPTION
Currently, publish method returns true or false, in the documentation, it says 

"amplify.publish returns a boolean indicating whether any subscriptions returned false. The return value is true if none of the subscriptions returned false, and false otherwise. Note that only one subscription can return false because doing so will prevent additional subscriptions from being invoked."

Quoting: "The return value is true if none of the subscriptions returned false, and false otherwise."

What if there are no subscriptions yet? It will still return true? 

So this is a suggestion to the feature to inform that when there are not subscriptions yet it will return null.
