### PR TITLE
Allow decoder to be define on request

### DIFF
--- a/src/request.js
+++ b/src/request.js
@@ -388,7 +388,7 @@ amplify.request.decoders = {
 amplify.subscribe( "request.before.ajax", function( resource, settings, ajaxSettings, ampXHR ) {
   var _success = ampXHR.success,
     _error = ampXHR.error,
-    decoder = resource.decoder || settings.decoder,
+    decoder = settings.decoder || resource.decoder,
     decoder = $.isFunction( decoder ) ?
       decoder :
       decoder in amplify.request.decoders ?

--- a/src/request.js
+++ b/src/request.js
@@ -386,13 +386,14 @@ amplify.request.decoders = {
 };
 
 amplify.subscribe( "request.before.ajax", function( resource, settings, ajaxSettings, ampXHR ) {
-	var _success = ampXHR.success,
-		_error = ampXHR.error,
-		decoder = $.isFunction( resource.decoder ) ?
-			resource.decoder :
-			resource.decoder in amplify.request.decoders ?
-				amplify.request.decoders[ resource.decoder ] :
-				amplify.request.decoders._default;
+  var _success = ampXHR.success,
+    _error = ampXHR.error,
+    decoder = resource.decoder || settings.decoder,
+    decoder = $.isFunction( decoder ) ?
+      decoder :
+      decoder in amplify.request.decoders ?
+        amplify.request.decoders[ decoder ] :
+        amplify.request.decoders._default;
 
 	if ( !decoder ) {
 		return;


### PR DESCRIPTION
Defining decoders on each request allow you to use different decoders over one request definition. 
You can still have a default decoder.

This way we can ask for the same resource and use different parsing.
