### PR TITLE
#29 adding clearAllSubscriptions method to amplify.core.js

### DIFF
--- a/lib/amplify.core.js
+++ b/lib/amplify.core.js
@@ -7,118 +7,123 @@
  *
  * http://amplifyjs.com
  */
-(function( global, undefined ) {
+(function(global, undefined) {
+  var slice = [].slice,
+    subscriptions = {};
 
-var slice = [].slice,
-	subscriptions = {};
+  var amplify = (global.amplify = {
+    clearAllSubscriptions: function() {
+      subscriptions = {};
+    },
+    publish: function(topic) {
+      if (typeof topic !== 'string') {
+        throw new Error('You must provide a valid topic to publish.');
+      }
 
-var amplify = global.amplify = {
-	publish: function( topic ) {
-		if ( typeof topic !== "string" ) {
-			throw new Error( "You must provide a valid topic to publish." );
-		}
+      var args = slice.call(arguments, 1),
+        topicSubscriptions,
+        subscription,
+        length,
+        i = 0,
+        ret;
 
-		var args = slice.call( arguments, 1 ),
-			topicSubscriptions,
-			subscription,
-			length,
-			i = 0,
-			ret;
+      if (!subscriptions[topic]) {
+        return true;
+      }
 
-		if ( !subscriptions[ topic ] ) {
-			return true;
-		}
+      topicSubscriptions = subscriptions[topic].slice();
+      for (length = topicSubscriptions.length; i < length; i++) {
+        subscription = topicSubscriptions[i];
+        ret = subscription.callback.apply(subscription.context, args);
+        if (ret === false) {
+          break;
+        }
+      }
+      return ret !== false;
+    },
 
-		topicSubscriptions = subscriptions[ topic ].slice();
-		for ( length = topicSubscriptions.length; i < length; i++ ) {
-			subscription = topicSubscriptions[ i ];
-			ret = subscription.callback.apply( subscription.context, args );
-			if ( ret === false ) {
-				break;
-			}
-		}
-		return ret !== false;
-	},
+    subscribe: function(topic, context, callback, priority) {
+      if (typeof topic !== 'string') {
+        throw new Error(
+          'You must provide a valid topic to create a subscription.',
+        );
+      }
 
-	subscribe: function( topic, context, callback, priority ) {
-		if ( typeof topic !== "string" ) {
-			throw new Error( "You must provide a valid topic to create a subscription." );
-		}
+      if (arguments.length === 3 && typeof callback === 'number') {
+        priority = callback;
+        callback = context;
+        context = null;
+      }
+      if (arguments.length === 2) {
+        callback = context;
+        context = null;
+      }
+      priority = priority || 10;
 
-		if ( arguments.length === 3 && typeof callback === "number" ) {
-			priority = callback;
-			callback = context;
-			context = null;
-		}
-		if ( arguments.length === 2 ) {
-			callback = context;
-			context = null;
-		}
-		priority = priority || 10;
+      var topicIndex = 0,
+        topics = topic.split(/\s/),
+        topicLength = topics.length,
+        added;
+      for (; topicIndex < topicLength; topicIndex++) {
+        topic = topics[topicIndex];
+        added = false;
+        if (!subscriptions[topic]) {
+          subscriptions[topic] = [];
+        }
 
-		var topicIndex = 0,
-			topics = topic.split( /\s/ ),
-			topicLength = topics.length,
-			added;
-		for ( ; topicIndex < topicLength; topicIndex++ ) {
-			topic = topics[ topicIndex ];
-			added = false;
-			if ( !subscriptions[ topic ] ) {
-				subscriptions[ topic ] = [];
-			}
+        var i = subscriptions[topic].length - 1,
+          subscriptionInfo = {
+            callback: callback,
+            context: context,
+            priority: priority,
+          };
 
-			var i = subscriptions[ topic ].length - 1,
-				subscriptionInfo = {
-					callback: callback,
-					context: context,
-					priority: priority
-				};
+        for (; i >= 0; i--) {
+          if (subscriptions[topic][i].priority <= priority) {
+            subscriptions[topic].splice(i + 1, 0, subscriptionInfo);
+            added = true;
+            break;
+          }
+        }
 
-			for ( ; i >= 0; i-- ) {
-				if ( subscriptions[ topic ][ i ].priority <= priority ) {
-					subscriptions[ topic ].splice( i + 1, 0, subscriptionInfo );
-					added = true;
-					break;
-				}
-			}
+        if (!added) {
+          subscriptions[topic].unshift(subscriptionInfo);
+        }
+      }
 
-			if ( !added ) {
-				subscriptions[ topic ].unshift( subscriptionInfo );
-			}
-		}
+      return callback;
+    },
 
-		return callback;
-	},
+    unsubscribe: function(topic, context, callback) {
+      if (typeof topic !== 'string') {
+        throw new Error(
+          'You must provide a valid topic to remove a subscription.',
+        );
+      }
 
-	unsubscribe: function( topic, context, callback ) {
-		if ( typeof topic !== "string" ) {
-			throw new Error( "You must provide a valid topic to remove a subscription." );
-		}
+      if (arguments.length === 2) {
+        callback = context;
+        context = null;
+      }
 
-		if ( arguments.length === 2 ) {
-			callback = context;
-			context = null;
-		}
+      if (!subscriptions[topic]) {
+        return;
+      }
 
-		if ( !subscriptions[ topic ] ) {
-			return;
-		}
+      var length = subscriptions[topic].length,
+        i = 0;
 
-		var length = subscriptions[ topic ].length,
-			i = 0;
+      for (; i < length; i++) {
+        if (subscriptions[topic][i].callback === callback) {
+          if (!context || subscriptions[topic][i].context === context) {
+            subscriptions[topic].splice(i, 1);
 
-		for ( ; i < length; i++ ) {
-			if ( subscriptions[ topic ][ i ].callback === callback ) {
-				if ( !context || subscriptions[ topic ][ i ].context === context ) {
-					subscriptions[ topic ].splice( i, 1 );
-					
-					// Adjust counter and length for removed item
-					i--;
-					length--;
-				}
-			}
-		}
-	}
-};
-
-}( this ) );
+            // Adjust counter and length for removed item
+            i--;
+            length--;
+          }
+        }
+      }
+    },
+  });
+})(this);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,96 @@
+{
+  "name": "amplify",
+  "version": "1.1.2",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "anvil.uglify": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/anvil.uglify/-/anvil.uglify-0.1.0.tgz",
+      "integrity": "sha1-O+H8JPUVdD8v3BDj5X0PGYRktN0=",
+      "dev": true,
+      "requires": {
+        "uglify-js": "~1.3.3"
+      }
+    },
+    "async": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+      "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.10"
+      }
+    },
+    "bufferedstream": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/bufferedstream/-/bufferedstream-1.6.0.tgz",
+      "integrity": "sha1-G1a+ZxMhYtn0aLyIbdLJFg3fKII=",
+      "dev": true
+    },
+    "graceful-fs": {
+      "version": "1.1.14",
+      "resolved": "http://registry.npmjs.org/graceful-fs/-/graceful-fs-1.1.14.tgz",
+      "integrity": "sha1-BweNtfY3f2Mh/Oqu30l94STclGU=",
+      "dev": true,
+      "optional": true
+    },
+    "lodash": {
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "dev": true
+    },
+    "markdown": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/markdown/-/markdown-0.3.1.tgz",
+      "integrity": "sha1-XZXBqGDRSFNSl4MqFX5L5Z6YgNQ=",
+      "dev": true
+    },
+    "mime": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.3.tgz",
+      "integrity": "sha1-dxe610RPQtDH2YzcKnsgBo+De2g=",
+      "dev": true
+    },
+    "rimraf": {
+      "version": "2.0.1",
+      "resolved": "http://registry.npmjs.org/rimraf/-/rimraf-2.0.1.tgz",
+      "integrity": "sha1-bli259OYC9YgYY0HA9UC+HIHj+4=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "~1.1"
+      }
+    },
+    "strata": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/strata/-/strata-0.20.1.tgz",
+      "integrity": "sha1-q8MOV/BOZICG/kwmSl+lWyOGV34=",
+      "dev": true,
+      "requires": {
+        "bufferedstream": "1.6.x",
+        "markdown": "~0.3.1",
+        "mime": "1.2.3",
+        "strftime": "0.4.6"
+      }
+    },
+    "strftime": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/strftime/-/strftime-0.4.6.tgz",
+      "integrity": "sha1-5v+RhD1O0U9Nw/JjvMX8i7WgJ6o=",
+      "dev": true
+    },
+    "uglify-js": {
+      "version": "1.3.5",
+      "resolved": "http://registry.npmjs.org/uglify-js/-/uglify-js-1.3.5.tgz",
+      "integrity": "sha1-S1v/+Rhu/7qoiOTJ6UvZ/EyUkp0=",
+      "dev": true
+    },
+    "underscore": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
+      "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==",
+      "dev": true
+    }
+  }
+}

--- a/src/amplify-vsdoc.js
+++ b/src/amplify-vsdoc.js
@@ -1,112 +1,113 @@
 /// >> amplify.request
 
 var amplify = {
-
-	request: function( resourceId ) {
-		/// <field name="decoders" type="Object">Decoders allow you to parse an ajax response before calling the success or error callback. This allows you to return data marked with a status and react accordingly. This also allows you to manipulate the data any way you want before passing the data along to the callback.</field>
-		/// <summary>
-		/// 	Request a resource.
-		/// 	&#10;Additional Signatures:
-		/// 	&#10;&#09;1. amplify.request( resourceId [, data [, callback ]] )
-		/// 	&#10;&#09;2. amplify.request( settings* )
-		/// 	&#10;&#10;API Reference: http://amplifyjs.com/api/request
-		/// </summary>
-		///	<param name="resourceId" type="String">Identifier string for the resource.</param>
-		///	<param name="data" type="Object" optional="true">An object literal of data to be sent to the resource.</param>
-		///	<param name="callback" type="Function" optional="true">A function to call once the resource has been retrieved.</param>
-		/// <param name="settings*" type="Hash">
-		///	* This parameter is only used with the #2 signature. A set of key/value pairs of settings for the request.
-		/// &#10;&#09;{
-		/// &#10;&#09;resourceId: Identifier string for the resource.
-		/// &#10;&#09;&#09;data (optional): Data associated with the request.
-		/// &#10;&#09;&#09;success (optional): Function to invoke on success.
-		/// &#10;&#09;&#09;error (optional): Function to invoke on error.		
-		/// &#10;&#09;}
-		///</param>
-		/// <returns type="Object">An object containing an 'abort' method</returns>
-	}
-
+  request: function(resourceId) {
+    /// <field name="decoders" type="Object">Decoders allow you to parse an ajax response before calling the success or error callback. This allows you to return data marked with a status and react accordingly. This also allows you to manipulate the data any way you want before passing the data along to the callback.</field>
+    /// <summary>
+    /// 	Request a resource.
+    /// 	&#10;Additional Signatures:
+    /// 	&#10;&#09;1. amplify.request( resourceId [, data [, callback ]] )
+    /// 	&#10;&#09;2. amplify.request( settings* )
+    /// 	&#10;&#10;API Reference: http://amplifyjs.com/api/request
+    /// </summary>
+    ///	<param name="resourceId" type="String">Identifier string for the resource.</param>
+    ///	<param name="data" type="Object" optional="true">An object literal of data to be sent to the resource.</param>
+    ///	<param name="callback" type="Function" optional="true">A function to call once the resource has been retrieved.</param>
+    /// <param name="settings*" type="Hash">
+    ///	* This parameter is only used with the #2 signature. A set of key/value pairs of settings for the request.
+    /// &#10;&#09;{
+    /// &#10;&#09;resourceId: Identifier string for the resource.
+    /// &#10;&#09;&#09;data (optional): Data associated with the request.
+    /// &#10;&#09;&#09;success (optional): Function to invoke on success.
+    /// &#10;&#09;&#09;error (optional): Function to invoke on error.
+    /// &#10;&#09;}
+    ///</param>
+    /// <returns type="Object">An object containing an 'abort' method</returns>
+  },
 };
 
 // stub for vsdoc
-amplify.request.decoders = { };
+amplify.request.decoders = {};
 
-amplify.request.define = function( resourceId, requestType, settings ) {
-	/// <summary>
-	/// 	Define a resource.
-	/// 	&#10;Additional Signatures:
-	/// 	&#10;&#09;1. amplify.request.define( resourceId* , resource* )
-	/// 	&#10;&#10;API Reference: http://amplifyjs.com/api/request/#usage
-	/// </summary>
-	///	<param name="resourceId" type="String">Identifier string for the resource.</param>
-	///	<param name="requestType" type="String">The type of data retrieval method from the server. See http://amplifyjs.com/api/request/#request_types for more information.</param>
-	///	<param name="settings" type="Hash">
-	///	A set of key/value pairs that relate to the server communication technology. Any settings found in jQuery.ajax() may be applied to this object.
-	/// &#10;&#09;{
-	/// &#10;&#09;&#09;cache: see the http://amplifyjs.com/api/request/#cache for more details.
-	/// &#10;&#09;&#09;decoder: see amplify.request.decoders for more details.
-	/// &#10;&#09;}
-	/// </param>
-	///	<param name="resourceId*" type="String">* This parameter is only used with the #1 additional signature. Identifier string for the resource.</param>
-	///	<param name="resource*" type="Function"> 
-	/// * This parameter is only used with the #1 additional signature. Function to handle requests. Receives a hash with the following properties:
-	/// &#10;&#09;{
-	/// &#10;&#09;&#09;resourceId: Identifier string for the resource.
-	/// &#10;&#09;&#09;data: Data provided by the user.
-	/// &#10;&#09;&#09;success: Callback to invoke on success.
-	/// &#10;&#09;&#09;error: Callback to invoke on error.
-	/// &#10;&#09;}
-	/// </param>
+amplify.request.define = function(resourceId, requestType, settings) {
+  /// <summary>
+  /// 	Define a resource.
+  /// 	&#10;Additional Signatures:
+  /// 	&#10;&#09;1. amplify.request.define( resourceId* , resource* )
+  /// 	&#10;&#10;API Reference: http://amplifyjs.com/api/request/#usage
+  /// </summary>
+  ///	<param name="resourceId" type="String">Identifier string for the resource.</param>
+  ///	<param name="requestType" type="String">The type of data retrieval method from the server. See http://amplifyjs.com/api/request/#request_types for more information.</param>
+  ///	<param name="settings" type="Hash">
+  ///	A set of key/value pairs that relate to the server communication technology. Any settings found in jQuery.ajax() may be applied to this object.
+  /// &#10;&#09;{
+  /// &#10;&#09;&#09;cache: see the http://amplifyjs.com/api/request/#cache for more details.
+  /// &#10;&#09;&#09;decoder: see amplify.request.decoders for more details.
+  /// &#10;&#09;}
+  /// </param>
+  ///	<param name="resourceId*" type="String">* This parameter is only used with the #1 additional signature. Identifier string for the resource.</param>
+  ///	<param name="resource*" type="Function">
+  /// * This parameter is only used with the #1 additional signature. Function to handle requests. Receives a hash with the following properties:
+  /// &#10;&#09;{
+  /// &#10;&#09;&#09;resourceId: Identifier string for the resource.
+  /// &#10;&#09;&#09;data: Data provided by the user.
+  /// &#10;&#09;&#09;success: Callback to invoke on success.
+  /// &#10;&#09;&#09;error: Callback to invoke on error.
+  /// &#10;&#09;}
+  /// </param>
 };
 
 /// >> amplify.store
 
-amplify.store = function( key, value, options ) {
-
-	/// <summary>
-	/// 	Stores a value for a given key using the default storage type.
-	/// 	&#10;Additional Signatures:
-	/// 	&#10;&#09;1. amplify.store() - Gets a hash of all stored values.
-	/// 	&#10;&#09;2.	amplify.store( string key ) - Gets a stored value based on the key.
-	/// 	&#10;&#09;3. amplify.store( string key, null ) - Clears key/value pair from the store.
-	/// 	&#10;&#10;API Reference: http://amplifyjs.com/api/store
-	/// </summary>
-	/// <param name="key" type="String">Identifier for the value being stored.</param>
-	/// <param name="value" type="Mixed">The value to store. The value can be anything that can be serialized as JSON.</param>
-	/// <param name="options" type="Hash" optional="true">A set of key/value pairs that relate to settings for storing the value.</param>
-	/// <returns type="Object">Depending on the signature used, the method will return the original object/data stored, or undefined.</returns>
+amplify.store = function(key, value, options) {
+  /// <summary>
+  /// 	Stores a value for a given key using the default storage type.
+  /// 	&#10;Additional Signatures:
+  /// 	&#10;&#09;1. amplify.store() - Gets a hash of all stored values.
+  /// 	&#10;&#09;2.	amplify.store( string key ) - Gets a stored value based on the key.
+  /// 	&#10;&#09;3. amplify.store( string key, null ) - Clears key/value pair from the store.
+  /// 	&#10;&#10;API Reference: http://amplifyjs.com/api/store
+  /// </summary>
+  /// <param name="key" type="String">Identifier for the value being stored.</param>
+  /// <param name="value" type="Mixed">The value to store. The value can be anything that can be serialized as JSON.</param>
+  /// <param name="options" type="Hash" optional="true">A set of key/value pairs that relate to settings for storing the value.</param>
+  /// <returns type="Object">Depending on the signature used, the method will return the original object/data stored, or undefined.</returns>
 };
 
 /// >> amplify.pub/sub
 
-amplify.subscribe = function( topic, callback ) {
-	/// <summary>
-	/// 	Subscribe to a message
-	/// 	&#10;Additional Signatures:
-	/// 	&#10;&#09;1. amplify.subscribe( topic, context, callback )
-	/// 	&#10;&#09;2. amplify.subscribe( topic, callback, priority )
-	/// 	&#10;&#09;3. amplify.subscribe( topic, context, callback, priority )
-	/// 	&#10;&#10;API Reference: http://amplifyjs.com/api/pubsub
-	/// </summary>
-	/// <param name="topic" type="String">Name of the message to subscribe to.</param>
-	/// <param name="context" type="Object" optional="true">What this will be when the callback is invoked.</param>
-	/// <param name="callback" type="Function">Function to invoke when the message is published.</param>
-	/// <param name="priority" type="Number" optional="true">Priority relative to other subscriptions for the same message. Lower values have higher priority. Default is 10.</param>
-};
- 
-amplify.unsubscribe = function( topic, callback ) {
-	/// <summary>Remove a subscription.</summary>
-	/// <param name="topic" type="String">The topic being unsubscribed from.</param>
-	/// <param name="context" type="Object" optional="true">If provided, only unsubscribes subscriptions that were bound with this context.</param>
-	/// <param name="callback" type="Function">The callback that was originally subscribed.</param>
+amplify.subscribe = function(topic, callback) {
+  /// <summary>
+  /// 	Subscribe to a message
+  /// 	&#10;Additional Signatures:
+  /// 	&#10;&#09;1. amplify.subscribe( topic, context, callback )
+  /// 	&#10;&#09;2. amplify.subscribe( topic, callback, priority )
+  /// 	&#10;&#09;3. amplify.subscribe( topic, context, callback, priority )
+  /// 	&#10;&#10;API Reference: http://amplifyjs.com/api/pubsub
+  /// </summary>
+  /// <param name="topic" type="String">Name of the message to subscribe to.</param>
+  /// <param name="context" type="Object" optional="true">What this will be when the callback is invoked.</param>
+  /// <param name="callback" type="Function">Function to invoke when the message is published.</param>
+  /// <param name="priority" type="Number" optional="true">Priority relative to other subscriptions for the same message. Lower values have higher priority. Default is 10.</param>
 };
 
-amplify.publish = function( topic ) {
-	/// <summary>
-	/// Publish a message.
-	/// &#10;Any number of additional parameters can be passed to the subscriptions
-	/// &#10;&#10;API Reference: http://amplifyjs.com/api/pubsub
-	/// </summary>
-	/// <param name="topic" type="String">The name of the message to publish.</param>
-	/// <returns type="Boolean">amplify.publish returns a boolean indicating whether any subscriptions returned false. The return value is true if none of the subscriptions returned false, and false otherwise. Note that only one subscription can return false because doing so will prevent additional subscriptions from being invoked.</returns>
+amplify.unsubscribe = function(topic, callback) {
+  /// <summary>Remove a subscription.</summary>
+  /// <param name="topic" type="String">The topic being unsubscribed from.</param>
+  /// <param name="context" type="Object" optional="true">If provided, only unsubscribes subscriptions that were bound with this context.</param>
+  /// <param name="callback" type="Function">The callback that was originally subscribed.</param>
+};
+
+amplify.clearAllSubscriptions = function() {
+  /// <summary>Remove all subscription.</summary>
+};
+
+amplify.publish = function(topic) {
+  /// <summary>
+  /// Publish a message.
+  /// &#10;Any number of additional parameters can be passed to the subscriptions
+  /// &#10;&#10;API Reference: http://amplifyjs.com/api/pubsub
+  /// </summary>
+  /// <param name="topic" type="String">The name of the message to publish.</param>
+  /// <returns type="Boolean">amplify.publish returns a boolean indicating whether any subscriptions returned false. The return value is true if none of the subscriptions returned false, and false otherwise. Note that only one subscription can return false because doing so will prevent additional subscriptions from being invoked.</returns>
 };

--- a/src/core.js
+++ b/src/core.js
@@ -1,115 +1,120 @@
-(function( global, undefined ) {
+(function(global, undefined) {
+  var slice = [].slice,
+    subscriptions = {};
 
-var slice = [].slice,
-	subscriptions = {};
+  var amplify = (global.amplify = {
+    clearAllSubscriptions: function() {
+      subscriptions = {};
+    },
+    publish: function(topic) {
+      if (typeof topic !== 'string') {
+        throw new Error('You must provide a valid topic to publish.');
+      }
 
-var amplify = global.amplify = {
-	publish: function( topic ) {
-		if ( typeof topic !== "string" ) {
-			throw new Error( "You must provide a valid topic to publish." );
-		}
+      var args = slice.call(arguments, 1),
+        topicSubscriptions,
+        subscription,
+        length,
+        i = 0,
+        ret;
 
-		var args = slice.call( arguments, 1 ),
-			topicSubscriptions,
-			subscription,
-			length,
-			i = 0,
-			ret;
+      if (!subscriptions[topic]) {
+        return true;
+      }
 
-		if ( !subscriptions[ topic ] ) {
-			return true;
-		}
+      topicSubscriptions = subscriptions[topic].slice();
+      for (length = topicSubscriptions.length; i < length; i++) {
+        subscription = topicSubscriptions[i];
+        ret = subscription.callback.apply(subscription.context, args);
+        if (ret === false) {
+          break;
+        }
+      }
+      return ret !== false;
+    },
 
-		topicSubscriptions = subscriptions[ topic ].slice();
-		for ( length = topicSubscriptions.length; i < length; i++ ) {
-			subscription = topicSubscriptions[ i ];
-			ret = subscription.callback.apply( subscription.context, args );
-			if ( ret === false ) {
-				break;
-			}
-		}
-		return ret !== false;
-	},
+    subscribe: function(topic, context, callback, priority) {
+      if (typeof topic !== 'string') {
+        throw new Error(
+          'You must provide a valid topic to create a subscription.',
+        );
+      }
 
-	subscribe: function( topic, context, callback, priority ) {
-		if ( typeof topic !== "string" ) {
-			throw new Error( "You must provide a valid topic to create a subscription." );
-		}
+      if (arguments.length === 3 && typeof callback === 'number') {
+        priority = callback;
+        callback = context;
+        context = null;
+      }
+      if (arguments.length === 2) {
+        callback = context;
+        context = null;
+      }
+      priority = priority || 10;
 
-		if ( arguments.length === 3 && typeof callback === "number" ) {
-			priority = callback;
-			callback = context;
-			context = null;
-		}
-		if ( arguments.length === 2 ) {
-			callback = context;
-			context = null;
-		}
-		priority = priority || 10;
+      var topicIndex = 0,
+        topics = topic.split(/\s/),
+        topicLength = topics.length,
+        added;
+      for (; topicIndex < topicLength; topicIndex++) {
+        topic = topics[topicIndex];
+        added = false;
+        if (!subscriptions[topic]) {
+          subscriptions[topic] = [];
+        }
 
-		var topicIndex = 0,
-			topics = topic.split( /\s/ ),
-			topicLength = topics.length,
-			added;
-		for ( ; topicIndex < topicLength; topicIndex++ ) {
-			topic = topics[ topicIndex ];
-			added = false;
-			if ( !subscriptions[ topic ] ) {
-				subscriptions[ topic ] = [];
-			}
+        var i = subscriptions[topic].length - 1,
+          subscriptionInfo = {
+            callback: callback,
+            context: context,
+            priority: priority,
+          };
 
-			var i = subscriptions[ topic ].length - 1,
-				subscriptionInfo = {
-					callback: callback,
-					context: context,
-					priority: priority
-				};
+        for (; i >= 0; i--) {
+          if (subscriptions[topic][i].priority <= priority) {
+            subscriptions[topic].splice(i + 1, 0, subscriptionInfo);
+            added = true;
+            break;
+          }
+        }
 
-			for ( ; i >= 0; i-- ) {
-				if ( subscriptions[ topic ][ i ].priority <= priority ) {
-					subscriptions[ topic ].splice( i + 1, 0, subscriptionInfo );
-					added = true;
-					break;
-				}
-			}
+        if (!added) {
+          subscriptions[topic].unshift(subscriptionInfo);
+        }
+      }
 
-			if ( !added ) {
-				subscriptions[ topic ].unshift( subscriptionInfo );
-			}
-		}
+      return callback;
+    },
 
-		return callback;
-	},
+    unsubscribe: function(topic, context, callback) {
+      if (typeof topic !== 'string') {
+        throw new Error(
+          'You must provide a valid topic to remove a subscription.',
+        );
+      }
 
-	unsubscribe: function( topic, context, callback ) {
-		if ( typeof topic !== "string" ) {
-			throw new Error( "You must provide a valid topic to remove a subscription." );
-		}
+      if (arguments.length === 2) {
+        callback = context;
+        context = null;
+      }
 
-		if ( arguments.length === 2 ) {
-			callback = context;
-			context = null;
-		}
+      if (!subscriptions[topic]) {
+        return;
+      }
 
-		if ( !subscriptions[ topic ] ) {
-			return;
-		}
+      var length = subscriptions[topic].length,
+        i = 0;
 
-		var length = subscriptions[ topic ].length,
-			i = 0;
+      for (; i < length; i++) {
+        if (subscriptions[topic][i].callback === callback) {
+          if (!context || subscriptions[topic][i].context === context) {
+            subscriptions[topic].splice(i, 1);
 
-		for ( ; i < length; i++ ) {
-			if ( subscriptions[ topic ][ i ].callback === callback ) {
-				if ( !context || subscriptions[ topic ][ i ].context === context ) {
-					subscriptions[ topic ].splice( i, 1 );
-					
-					// Adjust counter and length for removed item
-					i--;
-					length--;
-				}
-			}
-		}
-	}
-};
-
-}( this ) );
+            // Adjust counter and length for removed item
+            i--;
+            length--;
+          }
+        }
+      }
+    },
+  });
+})(this);

--- a/test/core/unit.js
+++ b/test/core/unit.js
@@ -1,259 +1,324 @@
-module( "amplify.core pubsub" );
+module('amplify.core pubsub');
 
-test( "topic", function() {
-	expect( 3 );
+test('topic', function() {
+  expect(3);
 
-	try {
-		amplify.publish( undefined, function() {} );
-	} catch( err ) {
-		strictEqual( err.message, "You must provide a valid topic to publish.",
-			"error with no topic to publish" );
-	}
+  try {
+    amplify.publish(undefined, function() {});
+  } catch (err) {
+    strictEqual(
+      err.message,
+      'You must provide a valid topic to publish.',
+      'error with no topic to publish',
+    );
+  }
 
-	try {
-		amplify.subscribe( undefined, function() {} );
-	} catch( err ) {
-		strictEqual( err.message, "You must provide a valid topic to create a subscription.",
-			"error with no topic to subscribe" );
-	}
+  try {
+    amplify.subscribe(undefined, function() {});
+  } catch (err) {
+    strictEqual(
+      err.message,
+      'You must provide a valid topic to create a subscription.',
+      'error with no topic to subscribe',
+    );
+  }
 
-	try {
-		amplify.unsubscribe( undefined, function() {} );
-	} catch( err ) {
-		strictEqual( err.message, "You must provide a valid topic to remove a subscription.",
-			"error with no topic to unsubscribe" );
-	}
+  try {
+    amplify.unsubscribe(undefined, function() {});
+  } catch (err) {
+    strictEqual(
+      err.message,
+      'You must provide a valid topic to remove a subscription.',
+      'error with no topic to unsubscribe',
+    );
+  }
 });
 
-test( "continuation", function() {
-	expect( 7 );
-	amplify.subscribe( "continuation", function() {
-		ok( true, "first subscriber called" );
-	});
-	amplify.subscribe( "continuation", function() {
-		ok( true, "continued after no return value" );
-		return true;
-	});
-	strictEqual( amplify.publish( "continuation" ), true,
-		"return true when subscriptions are not stopped" );
+test('continuation', function() {
+  expect(7);
+  amplify.subscribe('continuation', function() {
+    ok(true, 'first subscriber called');
+  });
+  amplify.subscribe('continuation', function() {
+    ok(true, 'continued after no return value');
+    return true;
+  });
+  strictEqual(
+    amplify.publish('continuation'),
+    true,
+    'return true when subscriptions are not stopped',
+  );
 
-	amplify.subscribe( "continuation", function() {
-		ok( true, "continued after returning true" );
-		return false;
-	});
-	amplify.subscribe( "continuation", function() {
-		ok( false, "continued after returning false" );
-	});
-	strictEqual( amplify.publish( "continuation" ), false,
-		"return false when subscriptions are stopped" );
+  amplify.subscribe('continuation', function() {
+    ok(true, 'continued after returning true');
+    return false;
+  });
+  amplify.subscribe('continuation', function() {
+    ok(false, 'continued after returning false');
+  });
+  strictEqual(
+    amplify.publish('continuation'),
+    false,
+    'return false when subscriptions are stopped',
+  );
 });
 
-test( "priority", function() {
-	expect( 5 );
-	var order = 0;
+test('priority', function() {
+  expect(5);
+  var order = 0;
 
-	amplify.subscribe( "priority", function() {
-		strictEqual( order, 1, "priority default; #1" );
-		order++;
-	});
-	amplify.subscribe( "priority", function() {
-		strictEqual( order, 3, "priority 15; #1" );
-		order++;
-	}, 15 );
-	amplify.subscribe( "priority", function() {
-		strictEqual( order, 2, "priority default; #2" );
-		order++;
-	});
-	amplify.subscribe( "priority", function() {
-		strictEqual( order, 0, "priority 1; #1" );
-		order++;
-	}, 1 );
-	amplify.subscribe( "priority", {}, function() {
-		strictEqual( order, 4, "priority 15; #2" );
-		order++;
-	}, 15 );
-	amplify.publish( "priority" );
+  amplify.subscribe('priority', function() {
+    strictEqual(order, 1, 'priority default; #1');
+    order++;
+  });
+  amplify.subscribe(
+    'priority',
+    function() {
+      strictEqual(order, 3, 'priority 15; #1');
+      order++;
+    },
+    15,
+  );
+  amplify.subscribe('priority', function() {
+    strictEqual(order, 2, 'priority default; #2');
+    order++;
+  });
+  amplify.subscribe(
+    'priority',
+    function() {
+      strictEqual(order, 0, 'priority 1; #1');
+      order++;
+    },
+    1,
+  );
+  amplify.subscribe(
+    'priority',
+    {},
+    function() {
+      strictEqual(order, 4, 'priority 15; #2');
+      order++;
+    },
+    15,
+  );
+  amplify.publish('priority');
 });
 
-test( "context", function() {
-	expect( 3 );
-	var obj = {},
-		fn = function() {};
+test('context', function() {
+  expect(3);
+  var obj = {},
+    fn = function() {};
 
-	amplify.subscribe( "context", function() {
-		strictEqual( this, window, "default context" );
-	});
-	amplify.subscribe( "context", obj, function() {
-		strictEqual( this, obj, "object" );
-	});
-	amplify.subscribe( "context", fn, function() {
-		strictEqual( this, fn, "function" );
-	});
-	amplify.publish( "context" );
+  amplify.subscribe('context', function() {
+    strictEqual(this, window, 'default context');
+  });
+  amplify.subscribe('context', obj, function() {
+    strictEqual(this, obj, 'object');
+  });
+  amplify.subscribe('context', fn, function() {
+    strictEqual(this, fn, 'function');
+  });
+  amplify.publish('context');
 });
 
-test( "data", function() {
-	amplify.subscribe( "data", function( string, number, object ) {
-		strictEqual( string, "hello", "string passed" );
-		strictEqual( number, 5, "number passed" );
-		deepEqual( object, {
-			foo: "bar",
-			baz: "qux"
-		}, "object passed" );
-		string = "goodbye";
-		object.baz = "quux";
-	});
-	amplify.subscribe( "data", function( string, number, object ) {
-		strictEqual( string, "hello", "string unchanged" );
-		strictEqual( number, 5, "number unchanged" );
-		deepEqual( object, {
-			foo: "bar",
-			baz: "quux"
-		}, "object changed" );
-	});
+test('data', function() {
+  amplify.subscribe('data', function(string, number, object) {
+    strictEqual(string, 'hello', 'string passed');
+    strictEqual(number, 5, 'number passed');
+    deepEqual(
+      object,
+      {
+        foo: 'bar',
+        baz: 'qux',
+      },
+      'object passed',
+    );
+    string = 'goodbye';
+    object.baz = 'quux';
+  });
+  amplify.subscribe('data', function(string, number, object) {
+    strictEqual(string, 'hello', 'string unchanged');
+    strictEqual(number, 5, 'number unchanged');
+    deepEqual(
+      object,
+      {
+        foo: 'bar',
+        baz: 'quux',
+      },
+      'object changed',
+    );
+  });
 
-	var obj = {
-		foo: "bar",
-		baz: "qux"
-	};
-	amplify.publish( "data", "hello", 5, obj );
-	deepEqual( obj, {
-		foo: "bar",
-		baz: "quux"
-	}, "object updated" );
+  var obj = {
+    foo: 'bar',
+    baz: 'qux',
+  };
+  amplify.publish('data', 'hello', 5, obj);
+  deepEqual(
+    obj,
+    {
+      foo: 'bar',
+      baz: 'quux',
+    },
+    'object updated',
+  );
 });
 
-test( "unsubscribe", function() {
-	expect( 6 );
-	var order = 0;
+test('unsubscribe', function() {
+  expect(6);
+  var order = 0;
 
-	amplify.subscribe( "unsubscribe", function() {
-		strictEqual( order, 0, "first subscriber called" );
-		order++;
-	});
-	var fn = function() {
-		ok( false, "removed by original reference" );
-		order++;
-	};
-	amplify.subscribe( "unsubscribe", fn );
-	amplify.subscribe( "unsubscribe", function() {
-		strictEqual( order, 1, "second subscriber called" );
-		order++;
-	});
-	var fn2 = amplify.subscribe( "unsubscribe", function() {
-		ok( false, "removed by returned reference" );
-		order++;
-	});
-	amplify.unsubscribe( "unsubscribe", fn );
-	amplify.unsubscribe( "unsubscribe", fn2 );
-	try {
-		amplify.unsubscribe( "unsubscribe", function() {});
-		ok( true, "no error with invalid handler" );
-	} catch ( e ) {
-		ok( false, "error with invalid handler" );
-	}
-	try {
-		amplify.unsubscribe( "unsubscribe2", function() {});
-		ok( true, "no error with invalid topic" );
-	} catch ( e ) {
-		ok( false, "error with invalid topic" );
-	}
+  amplify.subscribe('unsubscribe', function() {
+    strictEqual(order, 0, 'first subscriber called');
+    order++;
+  });
+  var fn = function() {
+    ok(false, 'removed by original reference');
+    order++;
+  };
+  amplify.subscribe('unsubscribe', fn);
+  amplify.subscribe('unsubscribe', function() {
+    strictEqual(order, 1, 'second subscriber called');
+    order++;
+  });
+  var fn2 = amplify.subscribe('unsubscribe', function() {
+    ok(false, 'removed by returned reference');
+    order++;
+  });
+  amplify.unsubscribe('unsubscribe', fn);
+  amplify.unsubscribe('unsubscribe', fn2);
+  try {
+    amplify.unsubscribe('unsubscribe', function() {});
+    ok(true, 'no error with invalid handler');
+  } catch (e) {
+    ok(false, 'error with invalid handler');
+  }
+  try {
+    amplify.unsubscribe('unsubscribe2', function() {});
+    ok(true, 'no error with invalid topic');
+  } catch (e) {
+    ok(false, 'error with invalid topic');
+  }
 
-	amplify.publish( "unsubscribe" );
+  amplify.publish('unsubscribe');
 
-	var counter = 0;
-	var fn3 = function () {
-		counter++;
-	};
+  var counter = 0;
+  var fn3 = function() {
+    counter++;
+  };
 
-	amplify.subscribe( "counter", fn3 );
-	amplify.subscribe( "counter", function () { });
-	amplify.subscribe( "counter", fn3 );
-	amplify.publish( "counter" );
-	strictEqual( counter, 2, "Two calls made" );
-	
-	amplify.unsubscribe( "counter", fn3 );
-	amplify.publish( "counter" );
+  amplify.subscribe('counter', fn3);
+  amplify.subscribe('counter', function() {});
+  amplify.subscribe('counter', fn3);
+  amplify.publish('counter');
+  strictEqual(counter, 2, 'Two calls made');
 
-	strictEqual( counter, 2, "Both subscriptions were unsubscribed" );
+  amplify.unsubscribe('counter', fn3);
+  amplify.publish('counter');
+
+  strictEqual(counter, 2, 'Both subscriptions were unsubscribed');
 });
 
-test( "unsubscribe with context", function () {
-	expect( 5 );
+test('unsubscribe with context', function() {
+  expect(5);
 
-	var calls = "";
+  var calls = '';
 
-	var A = function ( name ) {
-		this.name = name;
-		amplify.subscribe('myevent', this, this.doIt)
-	};
+  var A = function(name) {
+    this.name = name;
+    amplify.subscribe('myevent', this, this.doIt);
+  };
 
-	A.prototype = {
-		doIt: function () {
-			calls += this.name;
-		}
-	}
+  A.prototype = {
+    doIt: function() {
+      calls += this.name;
+    },
+  };
 
-	var x = new A( "x" ), y = new A( "y" );
+  var x = new A('x'),
+    y = new A('y');
 
-	amplify.publish( 'myevent' );
-	strictEqual( calls, "xy", "There should be two calls" );
+  amplify.publish('myevent');
+  strictEqual(calls, 'xy', 'There should be two calls');
 
-	amplify.unsubscribe('myevent', y.doIt);
-	amplify.publish( 'myevent' );	
-	strictEqual( calls, "xy", "There should be no new calls" );
+  amplify.unsubscribe('myevent', y.doIt);
+  amplify.publish('myevent');
+  strictEqual(calls, 'xy', 'There should be no new calls');
 
-	x = new A( "x" );
-	y = new A( "y" );
+  x = new A('x');
+  y = new A('y');
 
-	amplify.publish( 'myevent' );
-	strictEqual( calls, "xyxy", "There should be two new calls" );
+  amplify.publish('myevent');
+  strictEqual(calls, 'xyxy', 'There should be two new calls');
 
-	amplify.unsubscribe('myevent', y, y.doIt);
-	amplify.publish( 'myevent' );
-	strictEqual( calls, "xyxyx", "There should be one new call" );
+  amplify.unsubscribe('myevent', y, y.doIt);
+  amplify.publish('myevent');
+  strictEqual(calls, 'xyxyx', 'There should be one new call');
 
-	amplify.unsubscribe('myevent', x, x.doIt);
-	amplify.publish( 'myevent' );
-	strictEqual( calls, "xyxyx", "There should be no new calls" );
+  amplify.unsubscribe('myevent', x, x.doIt);
+  amplify.publish('myevent');
+  strictEqual(calls, 'xyxyx', 'There should be no new calls');
 });
 
-test( "unsubscribe during publish", function() {
-	expect( 3 );
+test('unsubscribe during publish', function() {
+  expect(3);
 
-	function racer() {
-		ok( true, "second" );
-		amplify.unsubscribe( "racy", racer );
-	}
+  function racer() {
+    ok(true, 'second');
+    amplify.unsubscribe('racy', racer);
+  }
 
-	amplify.subscribe( "racy", function() {
-		ok( true, "first" );
-	});
-	amplify.subscribe( "racy", racer );
-	amplify.subscribe( "racy", function() {
-		ok( true, "third" );
-	});
-	amplify.publish( "racy" );
+  amplify.subscribe('racy', function() {
+    ok(true, 'first');
+  });
+  amplify.subscribe('racy', racer);
+  amplify.subscribe('racy', function() {
+    ok(true, 'third');
+  });
+  amplify.publish('racy');
 });
 
-test( "multiple subscriptions", function() {
-	expect( 4 );
+test('multiple subscriptions', function() {
+  expect(4);
 
-	amplify.subscribe( "sub-a-1 sub-a-2 sub-a-3", function() {
-		ok( true );
-	});
-	amplify.publish( "sub-a-1" );
+  amplify.subscribe('sub-a-1 sub-a-2 sub-a-3', function() {
+    ok(true);
+  });
+  amplify.publish('sub-a-1');
 
-	amplify.subscribe( "sub-b-1 sub-b-2", function() {
-		ok( true );
-	});
-	
-	// Test for Ticket #18
-	amplify.subscribe( "sub-b-1 sub-b-3", function() {
-		ok( true );
-	});
-	
-	amplify.publish( "sub-b-2" );
-	amplify.publish( "sub-b-2" );
-	amplify.publish( "sub-b-3" );
+  amplify.subscribe('sub-b-1 sub-b-2', function() {
+    ok(true);
+  });
+
+  // Test for Ticket #18
+  amplify.subscribe('sub-b-1 sub-b-3', function() {
+    ok(true);
+  });
+
+  amplify.publish('sub-b-2');
+  amplify.publish('sub-b-2');
+  amplify.publish('sub-b-3');
+});
+
+test('clear all subscriptions', function() {
+  expect(0);
+
+  amplify.subscribe('sub-a-1 sub-a-2 sub-a-3', function() {
+    ok(true);
+  });
+
+  amplify.subscribe('sub-b-1 sub-b-2', function() {
+    ok(true);
+  });
+
+  // Test for Ticket #18
+  amplify.subscribe('sub-b-1 sub-b-3', function() {
+    ok(true);
+  });
+
+  amplify.clearAllSubscriptions();
+
+  amplify.publish('sub-a-1');
+  amplify.publish('sub-b-2');
+  amplify.publish('sub-b-2');
+  amplify.publish('sub-b-3');
 });


### PR DESCRIPTION
# Checklist
```
 [-] Added new method
 [-] Added new tests  
 [-] Updated vsdocs 
 ```
 ## What is the current behavior ?

There is no way to clear all of the internal subscriptions. 

## What is the new behavior ?

Now user can clear all of the internal subscriptions whenever they need by calling newly `clearAllSubscriptions` method.

## Does this PR introduce a breaking change?

NO

